### PR TITLE
Updating extension to accomodate running headless for tests and addin…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,13 @@ enablePlugins(org.nlogo.build.NetLogoExtension)
 
 scalaSource in Compile := baseDirectory.value / "src" / "main"
 
-netLogoClassManager := "NetLogoReflectionScala"
+scalaSource in Test := baseDirectory.value / "src" / "test"
+
+netLogoClassManager := "org.nlogo.extensions.reflection.NetLogoReflectionScala"
 
 netLogoVersion := "6.0.1-M1"
+
+netLogoTarget := NetLogoExtension.directoryTarget(baseDirectory.value)
 
 lazy val root = (project in file(".")).
   settings(
@@ -13,4 +17,31 @@ lazy val root = (project in file(".")).
       ,version      := "0.1.0-SNAPSHOT"
     ))
     ,name :=  "reflection"
+    ,libraryDependencies ++= Seq(
+      "org.picocontainer"  % "picocontainer" % "2.13.6" % "test",
+      "org.scalatest" %% "scalatest" % "3.0.0" % "test",
+      "org.ow2.asm" % "asm-all" % "5.0.3"  % "test"
+    )
   )
+
+val moveToRefDir = taskKey[Unit]("add all resources to Reflection directory")
+
+val refDirectory = settingKey[File]("directory that extension is moved to for testing")
+
+refDirectory := baseDirectory.value / "extensions" / "reflection"
+
+moveToRefDir := {
+  (packageBin in Compile).value
+  val testTarget = NetLogoExtension.directoryTarget(refDirectory.value)
+  testTarget.create(NetLogoExtension.netLogoPackagedFiles.value)
+  val testResources = (baseDirectory.value / "test" ***).filter(_.isFile)
+  for (file <- testResources.get)
+    IO.copyFile(file, refDirectory.value / "test" / IO.relativize(baseDirectory.value / "test", file).get)
+}
+
+test in Test := {
+  IO.createDirectory(refDirectory.value)
+  moveToRefDir.value
+  (test in Test).value
+  IO.delete(refDirectory.value)
+}

--- a/src/main/NetLogoReflectionScala.scala
+++ b/src/main/NetLogoReflectionScala.scala
@@ -22,7 +22,6 @@ class Globals extends Reporter {
   override def report(args: Array[Argument], context: Context): AnyRef = {
     context match {
       case extContext: ExtensionContext => {
-        //if (extContext.nvmContext.workspace == null) {
         if (extContext.workspace == null) {
           throw new ExtensionException(s"We need a workspace : $extContext");
         }
@@ -43,7 +42,6 @@ class Breeds extends Reporter {
         // add turtle vars as a separate tuple
         val turtleInfo = new LogoListBuilder
         turtleInfo.add("TURTLES")
-        // val workspace = App.app.workspace;
         val workspace = extContext.workspace;
         val turtleVars = workspace.world.program.turtleVars.keys.toVector.toLogoList
         turtleInfo.add(turtleVars)
@@ -69,7 +67,6 @@ class Procedures extends Reporter {
   override def report(args: Array[Argument], context: Context): AnyRef = {
     context match {
       case extContext: ExtensionContext => {
-        //val workspace = App.app.workspace
         var workspace = extContext.workspace
         workspace.procedures.map {
           case (name, procedure) =>

--- a/src/test/Tests.scala
+++ b/src/test/Tests.scala
@@ -1,0 +1,5 @@
+package org.nlogo.extensions.reflection
+
+import org.nlogo.headless.TestLanguage
+
+class Tests extends TestLanguage(Seq(new java.io.File("tests.txt").getCanonicalFile))

--- a/tests.txt
+++ b/tests.txt
@@ -1,0 +1,57 @@
+reflection-gets-globals-when-none-defined
+  extensions [ reflection ]
+  globals [ ]
+  breed [ cars car ]
+  turtles-own [ turt1 ]
+  cars-own [ cars1 ]
+  reflection:globals => []
+
+
+reflection-gets-globals
+  extensions [ reflection ]
+  globals [ glob1 ]
+  breed [ cars car ]
+  turtles-own [ turt1 ]
+  cars-own [ cars1 ]
+  reflection:globals => ["GLOB1"]
+
+reflection-gets-breeds-works-with-no-custom-defined
+  extensions [ reflection ]
+  globals [ glob1 ]
+  turtles-own [ turt1 ]
+  reflection:breeds => [["TURTLES" ["WHO" "COLOR" "HEADING" "XCOR" "YCOR" "SHAPE" "LABEL" "LABEL-COLOR" "BREED" "HIDDEN?" "SIZE" "PEN-SIZE" "PEN-MODE" "TURT1"]]]
+
+reflection-gets-breeds-works-with-custom
+  extensions [ reflection ]
+  globals [ glob1 ]
+  breed [ cars car ]
+  breed [ vans van ]
+  turtles-own [ turt1 ]
+  cars-own [ cars1 ]
+  reflection:breeds => [["TURTLES" ["WHO" "COLOR" "HEADING" "XCOR" "YCOR" "SHAPE" "LABEL" "LABEL-COLOR" "BREED" "HIDDEN?" "SIZE" "PEN-SIZE" "PEN-MODE" "TURT1"]] ["CARS" ["CARS1"]] ["VANS" []]]
+
+reflection-gets-procedures-works-when-none-defined
+  extensions [ reflection ]
+  reflection:procedures => []
+
+reflection-gets-procedures
+  extensions [ reflection ]
+  to-report rev [tacos] report (tacos - 1) end
+  to start let vs 0 show vs end
+  reflection:procedures => [["REV" "REPORTER" "OTPL" ["TACOS"]] ["START" "COMMAND" "OTPL" []]]
+
+reflection-gets-current-procedure
+  extensions [ reflection ]
+  to-report rev [tacos] set tacos (tacos - 1) report reflection:current-procedure end
+  to start let vs 0 show vs end
+  rev 10 => "REV"
+
+*reflection-gets-current-procedure-works-from-command
+  extensions [ reflection ]
+  reflection:current-procedure => "__EVALUATOR"
+
+*reflection-gets-callers
+  extensions [ reflection ]
+  to-report rev [tacos] set tacos (tacos - 1) report reflection:callers end
+  to start let vs 0 show vs end
+  rev 10 => ["REV" "__EVALUATOR"]


### PR DESCRIPTION
…g unit tests.

Switched to the extension context for grabbing the reflection info in all primitives so they'll run headless as well as in NetLogo desktop.  Added unit tests for some of the basic use cases for each primitive.    